### PR TITLE
docs: add development guide and refine roadmap and metadata

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,35 @@
+# Development Guide
+
+## Codebase Overview
+
+The project is a client-side web application that renders AI-generated coloring pages. The main files are:
+
+- `index.html` – core page markup and theme switcher.
+- `app.js` – application logic for fetching images and text, caching results, switching themes and styles, and handling route changes.
+- `test/` – unit tests covering API helpers, theme logic, style switching, and other utilities.
+- `test.html` – manual integration test page for exercising the Pollinations API from the browser.
+
+## Running the App
+
+Use the `npm start` script to serve the site locally on port 3000:
+
+```bash
+npm start
+```
+
+## Testing
+
+Automated tests live in the `test/` directory and run with Node's built-in test runner. Execute them with:
+
+```bash
+npm test
+```
+
+The suite validates API fallbacks, theme handling, caching helpers, and other utility functions. Tests can be extended by adding new files under `test/`.
+
+## Additional Documentation
+
+- **POLLINATIONS_INTEGRATION.md** – guidance on securing and using the Pollinations API.
+- **AI-APIDOCS.md** – detailed API reference.
+
+Keep documentation up to date when changing the public API or major application flows.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Navigate to a URL
 | Command | Description |
 |---------|-------------|
 | `npm start` | Start development server on localhost:3000 |
-| `npm test` | Run tests (placeholder) |
+| `npm test` | Run unit tests with Node's test runner |
 | `npm install` | Install dependencies |
 
 ## Project Structure
@@ -108,6 +108,22 @@ colorverse/
 ├── README.md         # This file
 └── assets/           # Static assets (if any)
 ```
+
+## Documentation
+
+- [DEVELOPMENT.md](DEVELOPMENT.md) – codebase overview and testing notes
+- [POLLINATIONS_INTEGRATION.md](POLLINATIONS_INTEGRATION.md) – Pollinations API usage guide
+- [AI-APIDOCS.md](AI-APIDOCS.md) – detailed API reference
+
+## Testing
+
+Run all unit tests with:
+
+```bash
+npm test
+```
+
+The suite covers API fallbacks, theme handling, caching helpers, and more. Test files reside in the `test/` directory.
 
 ## Credits
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,41 @@
+# Roadmap
+
+This document outlines competitors, high-ranking coloring keywords, and proposed features for Colorverse.
+
+## Competitors
+- Crayola (crayola.com)
+- Supercoloring (supercoloring.com)
+- HelloKids (hellokids.com)
+- JustColor (justcolor.net)
+- Coloring Home (coloringhome.com)
+- Disney Coloring Pages (disneyclips.com)
+- Faber-Castell Coloring Pages (faber-castell.com)
+- ColouringBook.com (coloring-book.info)
+- Coloring Pages for Kids (coloring-pages-kids.com)
+- Art Therapy Coloring (arttherapycoloring.com)
+
+## High-Ranking Coloring Keywords
+- free coloring pages
+- coloring pages for kids
+- adult coloring pages
+- printable coloring pages
+- online coloring book
+- coloring games
+- coloring sheets
+- coloring pages pdf
+- color by number
+- coloring book app
+
+## Proposed Features
+1. **Keyword-Focused Library** – Organize content around top keywords like "free coloring pages" and "coloring pages for kids" to boost search visibility.
+2. **Holiday & Seasonal Collections** – Release themed bundles for major holidays and seasons to keep the library fresh and relevant.
+3. **Newsletter & Email Updates** – Build an opt-in list to announce new coloring pages, seasonal collections, and special promotions.
+4. **Coloring Tips Infobox** – When a coloring page is shown, display a tooltip at the bottom with a random tip that teaches coloring techniques and color theory.
+5. **Tag-Based Search & Filtering** – Use tags for themes and difficulty to help visitors quickly find relevant pages.
+6. **Social Sharing Buttons** – One-click sharing options for popular platforms to promote finished artworks.
+7. **Accessibility Best Practices** – Semantic markup, alt text, and keyboard navigation to meet modern accessibility standards.
+8. **Structured Data & XML Sitemap** – Implement schema markup and generate a sitemap for better SEO performance.
+9. **Multi-Language Interface** – Localize menus and keywords to reach a global audience.
+10. **Analytics Dashboard** – Track page popularity and keyword performance to inform future content.
+11. **Color Palette Library** – Curated palettes and printable color charts to inspire color choices.
+

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="ColorVerse offers free printable and online coloring pages, coloring tips, and AI art for all ages.">
+    <meta name="keywords" content="free coloring pages, coloring pages for kids, adult coloring pages, printable coloring pages, online coloring book, coloring games, coloring sheets, coloring pages pdf, color by number, coloring book app">
     <title>ColorVerse - Free Coloring Pages & AI Art</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">

--- a/test.html
+++ b/test.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Internal test page for ColorVerse's Pollinations API integration.">
+    <meta name="keywords" content="free coloring pages, coloring pages for kids, adult coloring pages, printable coloring pages, online coloring book, coloring games, coloring sheets, coloring pages pdf, color by number, coloring book app">
     <title>Pollinations API Test Page - ColorVerse</title>
     <style>
         body {


### PR DESCRIPTION
## Summary
- add DEVELOPMENT.md with project overview and testing instructions
- expand README with documentation links and unit test guidance
- integrate top coloring keywords and descriptions into HTML metadata
- streamline roadmap by removing cross-promotional partnerships, artist spotlights, and educational worksheets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad549526288320a5b9c6b6ce013a17